### PR TITLE
Add search components and listing feed

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -9,9 +9,12 @@
       "version": "0.0.0",
       "dependencies": {
         "@heroicons/react": "^2.2.0",
+        "@radix-ui/react-avatar": "^1.0.4",
         "@radix-ui/react-dialog": "^1.1.14",
+        "@radix-ui/react-scroll-area": "^1.2.0",
         "@tailwindcss/postcss": "^4.1.11",
         "clsx": "^2.1.1",
+        "lucide-react": "^0.452.0",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "react-router-dom": "^7.7.1"
@@ -1407,11 +1410,44 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/@radix-ui/number": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/number/-/number-1.1.1.tgz",
+      "integrity": "sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g==",
+      "license": "MIT"
+    },
     "node_modules/@radix-ui/primitive": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.2.tgz",
       "integrity": "sha512-XnbHrrprsNqZKQhStrSwgRUQzoCI1glLzdw79xiZPoofhGICeZRSQ3dIxAKH1gb3OHfNf4d6f+vAv3kil2eggA==",
       "license": "MIT"
+    },
+    "node_modules/@radix-ui/react-avatar": {
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-avatar/-/react-avatar-1.1.10.tgz",
+      "integrity": "sha512-V8piFfWapM5OmNCXTzVQY+E1rDa53zY+MQ4Y7356v4fFz6vqCyUtIz2rUD44ZEdwg78/jKmMJHj07+C/Z/rcog==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-is-hydrated": "0.1.0",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@radix-ui/react-compose-refs": {
       "version": "1.1.2",
@@ -1475,6 +1511,21 @@
           "optional": true
         },
         "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-direction": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-direction/-/react-direction-1.1.1.tgz",
+      "integrity": "sha512-1UEWRX6jnOA2y4H5WczZ44gOOjTEmlqv1uNW4GAJEO5+bauCBhv8snY65Iw5/VOS/ghKN9gr2KjnLKxrsvoMVw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
           "optional": true
         }
       }
@@ -1635,6 +1686,37 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-scroll-area": {
+      "version": "1.2.9",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-scroll-area/-/react-scroll-area-1.2.9.tgz",
+      "integrity": "sha512-YSjEfBXnhUELsO2VzjdtYYD4CfQjvao+lhhrX5XsHD7/cyUNzljF1FHEbgTPN7LH2MClfwRMIsYlqTYpKTTe2A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/number": "1.1.1",
+        "@radix-ui/primitive": "1.1.2",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-presence": "1.1.4",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-slot": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
@@ -1712,6 +1794,24 @@
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-use-callback-ref": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-is-hydrated": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-is-hydrated/-/react-use-is-hydrated-0.1.0.tgz",
+      "integrity": "sha512-U+UORVEq+cTnRIaostJv9AGdV3G6Y+zbVd+12e18jQ5A3c0xL03IhnHuiU4UV69wolOQp5GfR58NW/EgdQhwOA==",
+      "license": "MIT",
+      "dependencies": {
+        "use-sync-external-store": "^1.5.0"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -3984,6 +4084,15 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/lucide-react": {
+      "version": "0.452.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.452.0.tgz",
+      "integrity": "sha512-kNefjOUOGm+Mu3KDiryONyPba9r+nhcrz5oJs3N6JDzGboQNEXw5GB3yB8rnV9/FA4bPyggNU6CRSihZm9MvSw==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0-rc"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.17",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.17.tgz",
@@ -4864,6 +4973,15 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.5.0.tgz",
+      "integrity": "sha512-Rb46I4cGGVBmjamjphe8L/UnvJD+uPPtTkNvX5mZgqdbavhI4EbgIWJiIHXJ8bc/i9EQGPRh4DwEURJ552Do0A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/vite": {

--- a/client/package.json
+++ b/client/package.json
@@ -11,9 +11,12 @@
   },
   "dependencies": {
     "@heroicons/react": "^2.2.0",
+    "@radix-ui/react-avatar": "^1.0.4",
     "@radix-ui/react-dialog": "^1.1.14",
+    "@radix-ui/react-scroll-area": "^1.2.0",
     "@tailwindcss/postcss": "^4.1.11",
     "clsx": "^2.1.1",
+    "lucide-react": "^0.452.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-router-dom": "^7.7.1"

--- a/client/src/components/atoms/AvatarPlaceholder.tsx
+++ b/client/src/components/atoms/AvatarPlaceholder.tsx
@@ -1,0 +1,28 @@
+import * as Avatar from '@radix-ui/react-avatar';
+import React from 'react';
+
+interface Props {
+  uri?: string;
+  alt?: string;
+  size?: number; // px (defaults to 56 = 14 × 4)
+}
+
+export function AvatarPlaceholder({ uri, alt = 'avatar', size = 56 }: Props) {
+  const dim = `${size}px`;
+  return (
+    <Avatar.Root
+      className='rounded-full overflow-hidden shrink-0 border border-slate-300 bg-slate-200'
+      style={{ width: dim, height: dim }}
+    >
+      {uri ? (
+        <Avatar.Image
+          src={uri}
+          alt={alt}
+          className='object-cover w-full h-full'
+        />
+      ) : (
+        <Avatar.Fallback delayMs={0} className='w-full h-full bg-slate-300' />
+      )}
+    </Avatar.Root>
+  );
+}

--- a/client/src/components/atoms/Icon.tsx
+++ b/client/src/components/atoms/Icon.tsx
@@ -1,0 +1,14 @@
+import * as LucideIcons from 'lucide-react';
+import { ComponentPropsWithoutRef, ElementType } from 'react';
+
+// Any icon name from lucide-react (e.g. 'Search', 'DollarSign')
+export type IconName = keyof typeof LucideIcons;
+
+type Props = {
+  name: IconName;
+} & ComponentPropsWithoutRef<ElementType>;
+
+export function Icon({ name, ...rest }: Props) {
+  const LucideIcon = LucideIcons[name] as ElementType;
+  return <LucideIcon size={18} {...rest} />;
+}

--- a/client/src/components/atoms/LocationText.tsx
+++ b/client/src/components/atoms/LocationText.tsx
@@ -1,0 +1,3 @@
+export function LocationText({ children }: { children: React.ReactNode }) {
+  return <span className='text-slate-600'>{children}</span>;
+}

--- a/client/src/components/atoms/PriceText.tsx
+++ b/client/src/components/atoms/PriceText.tsx
@@ -1,0 +1,4 @@
+export function PriceText({ value }: { value: number | string }) {
+  const display = typeof value === 'number' ? `$${value}` : value;
+  return <span className='font-medium text-slate-700'>{display}</span>;
+}

--- a/client/src/components/atoms/SearchInput.tsx
+++ b/client/src/components/atoms/SearchInput.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+
+export function SearchInput(
+  props: React.InputHTMLAttributes<HTMLInputElement>,
+) {
+  return (
+    <input
+      type='text'
+      {...props}
+      className={`flex-1 bg-transparent outline-none placeholder:text-slate-400 ${
+        props.className ?? ''
+      }`}
+    />
+  );
+}

--- a/client/src/components/atoms/index.ts
+++ b/client/src/components/atoms/index.ts
@@ -1,0 +1,6 @@
+export * from './Button';
+export * from './SearchInput';
+export * from './AvatarPlaceholder';
+export * from './Icon';
+export * from './PriceText';
+export * from './LocationText';

--- a/client/src/components/molecules/InfoRow.tsx
+++ b/client/src/components/molecules/InfoRow.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { Icon } from '../atoms/Icon';
+import { PriceText } from '../atoms/PriceText';
+import { LocationText } from '../atoms/LocationText';
+
+interface Props {
+  price: number;
+  location: string;
+}
+
+export function InfoRow({ price, location }: Props) {
+  return (
+    <div className='mt-2 flex items-center gap-3 text-sm'>
+      <Icon name='DollarSign' className='text-slate-500' />
+      <PriceText value={price} />
+      <Icon name='MapPin' className='ml-4 text-slate-500' />
+      <LocationText>{location}</LocationText>
+    </div>
+  );
+}

--- a/client/src/components/molecules/SearchBar.tsx
+++ b/client/src/components/molecules/SearchBar.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { Icon } from '../atoms/Icon';
+import { SearchInput } from '../atoms/SearchInput';
+
+interface Props {
+  value: string;
+  onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+}
+
+export function SearchBar({ value, onChange }: Props) {
+  return (
+    <label className='flex items-center gap-2 rounded-xl border border-slate-300 bg-white px-4 py-2 shadow-sm'>
+      <Icon name='Search' className='text-slate-500' />
+      <SearchInput
+        placeholder='Search flat‑shares'
+        value={value}
+        onChange={onChange}
+      />
+    </label>
+  );
+}

--- a/client/src/components/molecules/index.ts
+++ b/client/src/components/molecules/index.ts
@@ -1,0 +1,3 @@
+export * from './Header';
+export * from './SearchBar';
+export * from './InfoRow';

--- a/client/src/components/organisms/ListingCard.tsx
+++ b/client/src/components/organisms/ListingCard.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { AvatarPlaceholder } from '../atoms/AvatarPlaceholder';
+import { InfoRow } from '../molecules/InfoRow';
+
+export type Listing = {
+  id: string;
+  title: string;
+  price: number;
+  district: string;
+  avatarUrl?: string;
+};
+
+export function ListingCard({ listing }: { listing: Listing }) {
+  return (
+    <article className='flex gap-4 rounded-2xl border border-slate-300 bg-white p-4 shadow-sm'>
+      <AvatarPlaceholder uri={listing.avatarUrl} />
+      <div className='flex flex-1 flex-col'>
+        <h3 className='text-base font-semibold text-slate-700'>
+          {listing.title}
+        </h3>
+        <InfoRow price={listing.price} location={listing.district} />
+      </div>
+    </article>
+  );
+}

--- a/client/src/components/organisms/ListingFeed.tsx
+++ b/client/src/components/organisms/ListingFeed.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import * as ScrollArea from '@radix-ui/react-scroll-area';
+import { Listing, ListingCard } from './ListingCard';
+
+export function ListingFeed({ data }: { data: Listing[] }) {
+  return (
+    <ScrollArea.Root className='h-full w-full rounded-xl-clip border border-slate-300 bg-white'>
+      <ScrollArea.Viewport className='h-full w-full p-4 flex flex-col gap-4'>
+        {data.map((item) => (
+          <ListingCard key={item.id} listing={item} />
+        ))}
+      </ScrollArea.Viewport>
+      <ScrollArea.Scrollbar
+        orientation='vertical'
+        className='flex select-none touch-none p-0.5 bg-transparent hover:bg-slate-100'
+      >
+        <ScrollArea.Thumb className='flex-1 rounded-full bg-slate-400' />
+      </ScrollArea.Scrollbar>
+    </ScrollArea.Root>
+  );
+}

--- a/client/src/components/organisms/index.ts
+++ b/client/src/components/organisms/index.ts
@@ -1,0 +1,3 @@
+export * from './MainActions';
+export * from './ListingCard';
+export * from './ListingFeed';

--- a/client/src/hooks/useListings.ts
+++ b/client/src/hooks/useListings.ts
@@ -1,0 +1,23 @@
+import { useEffect, useState } from 'react';
+import { Listing } from '../components/organisms/ListingCard';
+
+export function useListings(search: string) {
+  const [data, setData] = useState<Listing[]>([]);
+
+  useEffect(() => {
+    const controller = new AbortController();
+
+    fetch(`/api/listings?search=${encodeURIComponent(search)}`, {
+      signal: controller.signal,
+    })
+      .then((res) => res.json())
+      .then(setData)
+      .catch((err) => {
+        if (err.name !== 'AbortError') console.error(err);
+      });
+
+    return () => controller.abort();
+  }, [search]);
+
+  return data;
+}

--- a/client/src/pages/SearchPage.tsx
+++ b/client/src/pages/SearchPage.tsx
@@ -1,0 +1,18 @@
+import React, { useState } from 'react';
+import { SearchBar } from '../components/molecules/SearchBar';
+import { ListingFeed } from '../components/organisms/ListingFeed';
+import { useListings } from '../hooks/useListings';
+
+export default function SearchPage() {
+  const [query, setQuery] = useState('');
+  const listings = useListings(query);
+
+  return (
+    <main className='flex min-h-screen flex-col gap-6 bg-slate-100 p-6'>
+      <SearchBar value={query} onChange={setQuery} />
+      <div className='flex-1'>
+        <ListingFeed data={listings} />
+      </div>
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
- build search UI atoms like SearchInput, AvatarPlaceholder, and Icon helpers
- compose molecules and organisms for listing cards and feeds
- add listings hook and search page, updating deps

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm install`

------
https://chatgpt.com/codex/tasks/task_e_68926de78eb88323816f4eae91468ab3