### PR TITLE
feat: add promo video and FAQ to main screen

### DIFF
--- a/client/src/components/organisms/Faq.tsx
+++ b/client/src/components/organisms/Faq.tsx
@@ -1,0 +1,38 @@
+export function Faq() {
+  const faqs = [
+    {
+      q: 'What is FlataMi?',
+      a: 'FlataMi helps you find verified flats and compatible flatmates.',
+    },
+    {
+      q: 'How do I post a listing?',
+      a: 'Sign up and use the "Add Listing" button to share your space.',
+    },
+    {
+      q: 'Is FlataMi free?',
+      a: 'Yes, browsing and posting listings are free of charge.',
+    },
+  ];
+
+  return (
+    <section className="mx-auto w-full max-w-6xl px-4 py-14">
+      <h2 className="text-center text-2xl font-bold text-gray-900 md:text-3xl">
+        FAQ
+      </h2>
+      <div className="mt-8 space-y-4">
+        {faqs.map((item) => (
+          <details
+            key={item.q}
+            className="rounded-lg border border-gray-200 bg-white p-4"
+          >
+            <summary className="cursor-pointer text-lg font-medium text-gray-900">
+              {item.q}
+            </summary>
+            <p className="mt-2 text-sm text-gray-600">{item.a}</p>
+          </details>
+        ))}
+      </div>
+    </section>
+  );
+}
+

--- a/client/src/components/organisms/PromoVideo.tsx
+++ b/client/src/components/organisms/PromoVideo.tsx
@@ -1,0 +1,19 @@
+export function PromoVideo() {
+  return (
+    <section className="mx-auto w-full max-w-6xl px-4 py-14 flex flex-col items-center">
+      <div className="w-full max-w-3xl">
+        <video
+          className="w-full rounded-lg shadow"
+          controls
+        >
+          <source src="https://www.w3schools.com/html/mov_bbb.mp4" type="video/mp4" />
+          Your browser does not support the video tag.
+        </video>
+      </div>
+      <p className="mt-4 text-center text-sm text-gray-600">
+        Learn how FlataMi can help you find your perfect flatmate.
+      </p>
+    </section>
+  );
+}
+

--- a/client/src/components/organisms/index.ts
+++ b/client/src/components/organisms/index.ts
@@ -5,3 +5,5 @@ export * from './ListingFeed';
 export { FlatmateCard } from './FlatmateCard';
 export type { Flatmate } from './FlatmateCard';
 export * from './FlatmateFeed';
+export * from './PromoVideo';
+export * from './Faq';

--- a/client/src/pages/MainScreen.tsx
+++ b/client/src/pages/MainScreen.tsx
@@ -2,6 +2,8 @@ import { Header } from '../components/molecules/Header';
 import { Hero } from '../components/organisms/Hero';
 import { MainActions } from '../components/organisms/MainActions';
 import { Features } from '../components/organisms/Features';
+import { PromoVideo } from '../components/organisms/PromoVideo';
+import { Faq } from '../components/organisms/Faq';
 import { Footer } from '../components/molecules/Footer';
 
 export default function MainScreen() {
@@ -11,25 +13,27 @@ export default function MainScreen() {
       <Header />
       <main className="flex-1">
         <Hero />
-          <section
-            className="relative min-h-[60vh]"
-            style={{
-              backgroundImage: "url('/public/backgrounds/cozy_apartment_background.png')",
-              backgroundSize: 'cover',
-              backgroundPosition: 'center',
-              backgroundRepeat: 'no-repeat',
-            }}
-          >
-            <div className="mx-auto mt-10 max-w-6xl px-4">
-              <MainActions />
-            </div>
-            <div className="relative">
+        <section
+          className="relative min-h-[60vh]"
+          style={{
+            backgroundImage: "url('/public/backgrounds/cozy_apartment_background.png')",
+            backgroundSize: 'cover',
+            backgroundPosition: 'center',
+            backgroundRepeat: 'no-repeat',
+          }}
+        >
+          <div className="mx-auto mt-10 max-w-6xl px-4">
+            <MainActions />
+          </div>
+          <div className="relative">
             <Features />
-            </div>
-          </section>
-
+          </div>
+        </section>
+        <PromoVideo />
+        <Faq />
       </main>
       <Footer />
     </div>
   );
 }
+


### PR DESCRIPTION
## Summary
- embed placeholder promo video with descriptive text
- add accordion FAQ section with centered heading
- expose new components for reuse and render on main screen

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any in Hero.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_689724eb3d388323b1bd60c69069e343