### PR TITLE
Add dotenv configuration and MongoDB models

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+PORT=5000
+MONGO_URI=mongodb://localhost:27017/flatshare_db
+JWT_SECRET=supersecret_jwt_key
+GOOGLE_OAUTH_CLIENT_ID=your-google-client-id
+GOOGLE_OAUTH_CLIENT_SECRET=your-google-client-secret

--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ Thumbs.db
 # Environment files
 .env
 .env.*
+!.env.example
 
 # VS Code settings
 .vscode/

--- a/server/config/db.js
+++ b/server/config/db.js
@@ -1,0 +1,16 @@
+const mongoose = require('mongoose');
+
+async function connectDB() {
+  try {
+    await mongoose.connect(process.env.MONGO_URI, {
+      useNewUrlParser: true,
+      useUnifiedTopology: true,
+    });
+    console.log('MongoDB Connected');
+  } catch (err) {
+    console.error('DB connection error:', err);
+    process.exit(1);
+  }
+}
+
+module.exports = connectDB;

--- a/server/config/index.js
+++ b/server/config/index.js
@@ -1,0 +1,11 @@
+const dotenv = require('dotenv');
+
+dotenv.config();
+
+module.exports = {
+  port: process.env.PORT || 5000,
+  mongoURI: process.env.MONGO_URI,
+  jwtSecret: process.env.JWT_SECRET,
+  googleClientId: process.env.GOOGLE_OAUTH_CLIENT_ID,
+  googleClientSecret: process.env.GOOGLE_OAUTH_CLIENT_SECRET,
+};

--- a/server/models/listing.js
+++ b/server/models/listing.js
@@ -1,0 +1,20 @@
+const mongoose = require('mongoose');
+
+const listingSchema = new mongoose.Schema(
+  {
+    title: { type: String, required: true },
+    description: { type: String },
+    rent: { type: Number, required: true },
+    location: { type: String, required: true },
+    available: { type: Boolean, default: true },
+    availableFrom: { type: Date },
+    images: [String],
+    postedBy: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: 'User',
+    },
+  },
+  { timestamps: true },
+);
+
+module.exports = mongoose.model('Listing', listingSchema);

--- a/server/models/user.js
+++ b/server/models/user.js
@@ -1,0 +1,14 @@
+const mongoose = require('mongoose');
+
+const userSchema = new mongoose.Schema(
+  {
+    name: { type: String, required: true },
+    email: { type: String, required: true, unique: true },
+    password: { type: String, required: true },
+    googleId: { type: String },
+    facebookId: { type: String },
+  },
+  { timestamps: true },
+);
+
+module.exports = mongoose.model('User', userSchema);

--- a/server/package.json
+++ b/server/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "server",
+  "version": "1.0.0",
+  "description": "Express server for Flatami",
+  "main": "server.js",
+  "scripts": {
+    "dev": "nodemon server.js",
+    "start": "node server.js",
+    "test": "echo \"No tests yet\""
+  },
+  "dependencies": {
+    "dotenv": "^16.4.5",
+    "express": "^4.19.2",
+    "mongoose": "^7.6.1"
+  },
+  "devDependencies": {
+    "nodemon": "^3.1.0"
+  }
+}

--- a/server/server.js
+++ b/server/server.js
@@ -1,0 +1,17 @@
+const express = require('express');
+const connectDB = require('./config/db');
+const config = require('./config');
+
+const app = express();
+
+connectDB();
+
+app.use(express.json());
+
+app.get('/', (_req, res) => {
+  res.send('API running');
+});
+
+app.listen(config.port, () => {
+  console.log(`Server running on port ${config.port}`);
+});


### PR DESCRIPTION
## Summary
- scaffold server with Express and environment variable loader
- connect to MongoDB via Mongoose using centralized config
- add User and Listing schemas and example env file

## Testing
- `cd server && npm test`
- `cd client && npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_689b961a10608323bae8d08e98e5ab1f